### PR TITLE
Self surgery; also, brain damage makes surgery harder

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -74,6 +74,12 @@
 
 		if(implement_type)	//this means it isn't a require hand or any item step.
 			prob_chance = implements[implement_type]
+		// 413 -- brain damage reduces success probability (since we're allowing self-surgery)
+		var/brain_loss = user.getOrganLoss(ORGAN_SLOT_BRAIN)
+		if(brain_loss && brain_loss > BRAIN_DAMAGE_SEVERE)
+			brain_loss = brain_loss - BRAIN_DAMAGE_SEVERE
+			prob_chance -= (brain_loss) * (SURGERY_BRAIN_DAMAGE_PENALTY/(BRAIN_DAMAGE_DEATH - BRAIN_DAMAGE_SEVERE))
+		// 413 end
 		prob_chance *= surgery.get_propability_multiplier()
 
 		if((prob(prob_chance) || (iscyborg(user) && !silicons_obey_prob)) && chem_check(target) && !try_to_fail)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -1,3 +1,5 @@
+#define SURGERY_BRAIN_DAMAGE_PENALTY 50 // 413 -- make brain damage reduce surgery chance
+
 /datum/surgery_step
 	var/name
 	var/list/implements = list()	//format is path = probability of success. alternatively
@@ -75,10 +77,12 @@
 		if(implement_type)	//this means it isn't a require hand or any item step.
 			prob_chance = implements[implement_type]
 		// 413 -- brain damage reduces success probability (since we're allowing self-surgery)
-		var/brain_loss = user.getOrganLoss(ORGAN_SLOT_BRAIN)
-		if(brain_loss && brain_loss > BRAIN_DAMAGE_SEVERE)
-			brain_loss = brain_loss - BRAIN_DAMAGE_SEVERE
-			prob_chance -= (brain_loss) * (SURGERY_BRAIN_DAMAGE_PENALTY/(BRAIN_DAMAGE_DEATH - BRAIN_DAMAGE_SEVERE))
+		if(isliving(user))
+			var/mob/living/livingUser = user
+			var/brain_loss = livingUser.getOrganLoss(ORGAN_SLOT_BRAIN)
+			if(brain_loss && brain_loss > BRAIN_DAMAGE_SEVERE)
+				brain_loss = brain_loss - BRAIN_DAMAGE_SEVERE
+				prob_chance -= (brain_loss) * (SURGERY_BRAIN_DAMAGE_PENALTY/(BRAIN_DAMAGE_DEATH - BRAIN_DAMAGE_SEVERE))
 		// 413 end
 		prob_chance *= surgery.get_propability_multiplier()
 
@@ -150,3 +154,5 @@
 		detailed_mobs -= target //The patient can't see well what's going on, unless it's something like getting cut
 	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target_detailed ? null : target)
 	user.visible_message(vague_message, "", ignored_mobs = detailed_mobs)
+
+#undef SURGERY_BRAIN_DAMAGE_PENALTY // 413

--- a/spacestation413.dme
+++ b/spacestation413.dme
@@ -2969,5 +2969,6 @@
 #include "spacestation413\code\modules\spells\cluwnecurse.dm"
 #include "spacestation413\code\modules\spells\slip.dm"
 #include "spacestation413\code\modules\spells\spell_types\touch.dm"
+#include "spacestation413\code\modules\surgery\surgery.dm"
 #include "spacestation413\code\modules\surgery\organs\butts.dm"
 // END_INCLUDE

--- a/spacestation413/code/modules/surgery/surgery.dm
+++ b/spacestation413/code/modules/surgery/surgery.dm
@@ -1,0 +1,18 @@
+/datum/surgery
+	self_operable = TRUE //makes self surgery by default
+
+//i'm just gonna consolidate all the surgeries i'm opting out of self-surgery in here
+
+/datum/surgery/advanced
+	self_operable = FALSE //most advanced ones are pretty strong, but i can change them on a case-by-case basis
+	//giving a traitor roboticist or MD access to whatever surgeries is a bit much.
+
+/datum/surgery/advanced/lobotomy
+	self_operable = TRUE
+
+/datum/surgery/advanced/bioware/ligament_hook
+	self_operable = TRUE // these two have trade-offs so they're fine
+
+/datum/surgery/advanced/bioware/ligament_reinforcement
+	self_operable = TRUE
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes most surgeries self-surgeryable; to balance this, brain damage makes surgery up to twice as hard, starting at severe brain damage.

## Why It's Good For The Game

Low pop server, so surgery doesn't get much use; plus, it allows for better healing without chems, which is a bonus.

## Changelog
:cl:
tweak: made most surgeries self-surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
